### PR TITLE
Corrigindo o botão de download que não respondia ao clique

### DIFF
--- a/src/components/Pdf/index.tsx
+++ b/src/components/Pdf/index.tsx
@@ -67,7 +67,7 @@ export const CardPDF = ({name, repo, theme}: prfProps) => {
 
 function Banner({name, repo, theme}:prfProps) {
 return (
-    <PDFDownloadLink document={<CardPDF repo={repo} name={name} theme={theme} />} fileName="card.pdf">
+    <PDFDownloadLink style={{padding: "1.6rem 4rem"}} document={<CardPDF repo={repo} name={name} theme={theme} />} fileName="card.pdf">
       {({ blob, url, loading, error }) =>
         {
           return loading ? 'Loading ...' : 'Download'}

--- a/src/styles/post.ts
+++ b/src/styles/post.ts
@@ -57,7 +57,6 @@ export const PostDownloadButton = styled.button`
   height: 100vh;
   max-height: 6rem;
   font-size: 2.4rem;
-  padding: 1.6rem 4rem;
   border: 0;
   border-radius: 5px;
 


### PR DESCRIPTION
Este pull request corrige um erro no botão de download que não respondia ao clique. O problema estava relacionado ao padding que estava aplicado ao botão, em vez de estar na tag a (link), o que fazia com que o botão só funcionasse quando se clicava no link.

antes:
![antes](https://user-images.githubusercontent.com/87894998/224974438-339670d4-e4eb-45c8-bff2-c112b2f8929f.png)

depois:
![depois](https://user-images.githubusercontent.com/87894998/224974710-4541b5da-56e4-4f8a-9308-a6105adf3a2e.png)

Este ajuste permite que o botão de download funcione quando clicado em qualquer lugar dele, corrigindo o problema anterior que exigia o clique específico no link.